### PR TITLE
 Example using event bus and service proxies to connect vertx and node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ For vert.x version 2, check [this page](./vert-x2.md).
 * [Vert.x examples](https://github.com/vert-x3/vertx-examples) ![(stack)](stack.png "Vert.x Stack") - The official Vert.x examples including web examples, how to use the official database clients, ...
 * [Vert.x feeds](https://github.com/aesteve/vertx-feeds) - Example of an RSS aggregator built using Vert.x, Gradle, MongoDB, Redis, Handlebars templates, AngularJS, the event bus and SockJS
 * [Vert.x Markdown service](https://github.com/aesteve/vertx-markdown-service) - Example on how to use [service-proxy](https://github.com/vert-x3/vertx-service-proxy) with Gradle.
-* [Example using event bus and service proxies to connect vertx and node](https://github.com/advantageous/vertx-node-ec2-eventbus-example) Step by step example with WIKI description showing how to connect Vertx and Node using event bus and service proxies.
+* [Example using event bus and service proxies to connect vertx and node](https://github.com/advantageous/vertx-node-ec2-eventbus-example) - Step by step example with WIKI description showing how to connect Vertx and Node using event bus and service proxies.

--- a/README.md
+++ b/README.md
@@ -162,3 +162,4 @@ For vert.x version 2, check [this page](./vert-x2.md).
 * [Vert.x examples](https://github.com/vert-x3/vertx-examples) ![(stack)](stack.png "Vert.x Stack") - The official Vert.x examples including web examples, how to use the official database clients, ...
 * [Vert.x feeds](https://github.com/aesteve/vertx-feeds) - Example of an RSS aggregator built using Vert.x, Gradle, MongoDB, Redis, Handlebars templates, AngularJS, the event bus and SockJS
 * [Vert.x Markdown service](https://github.com/aesteve/vertx-markdown-service) - Example on how to use [service-proxy](https://github.com/vert-x3/vertx-service-proxy) with Gradle.
+* [Example using event bus and service proxies to connect vertx and node](https://github.com/advantageous/vertx-node-ec2-eventbus-example) Step by step example with WIKI description showing how to connect Vertx and Node using event bus and service proxies.


### PR DESCRIPTION
Example using event bus and service proxies to connect vertx and node - Step by step example with WIKI description showing how to connect Vertx and Node using event bus and service proxies.