### PR TITLE
Add vertx-sisu

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ For vert.x version 2, check [this page](./vert-x2.md).
 * [Maven Service Factory](https://github.com/vert-x3/vertx-maven-service-factory) ![(stack)](stack.png "Vert.x Stack") - Maven Vert.x Service Factory
 * [HTTP Service Factory](https://github.com/vert-x3/vertx-http-service-factory) ![(stack)](stack.png "Vert.x Stack") - Vert.x HTTP Service Factory
 * [Node.js Service Factory](https://github.com/mellster2012/vertx-nodejs-service-factory) - Vert.x Node.js Service Factory
+* [Eclipse SISU Service Factories](https://github.com/cstamas/vertx-sisu) - Vert.x integration with [Eclipse SISU](https://www.eclipse.org/sisu/) DI container offering alternatives for `vertx-service-factory` and `vertx-maven-service-factory`.
 
 ## Dependency Injection
 
@@ -158,6 +159,7 @@ For vert.x version 2, check [this page](./vert-x2.md).
 * [Spring Vert.x Extension](https://github.com/amoAHCP/spring-vertx-ext) - Vert.x verticle factory for Spring DI injection
 * [Vert.x Beans](https://github.com/rworsnop/vertx-beans) - Inject Vert.x objects as beans into your Spring application
 * [QBit](https://github.com/advantageous/qbit) - QBit works with Spring DI and Spring Boot (and of course Vertx). Allows you to use QBit, Vertx, Spring DI and Spring Boot in the same application.
+* [Vert.x Eclipse SISU](https://github.com/cstamas/vertx-sisu) - Vert.x integration with [Eclipse SISU](https://www.eclipse.org/sisu/) DI container.
 
 ## Development Tools
 


### PR DESCRIPTION
Adds https://github.com/cstamas/vertx-sisu to the list.

Given that project provides:
* SISU/Guice integration
* `vertx-service-factory` alternative
* `verx-maven-service-factory` alternative

I am unsure about proper categorisation, so please suggest.

Project is not yet released (is not in Central), hence am fine waiting with this PR until release happens (expected soon).

Thanks.