### PR TITLE
vertx-orientdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ For vert.x version 2, check [this page](./vert-x2.md).
   * [MongoDB](https://github.com/vert-x3/vertx-mongo-client) ![(stack)](stack.png "Vert.x Stack") - An asynchronous client for interacting with a MongoDB database
   * [Redis](https://github.com/vert-x3/vertx-redis-client) ![(stack)](stack.png "Vert.x Stack") - Asynchronous API to interact with Redis
   * [Cassandra](https://github.com/englishtown/vertx-cassandra) - Asynchronous API to interact with Cassandra and Cassandra Mapping
+  * [OrientDB](https://github.com/cstamas/vertx-orientdb) - nonblocking OrientDB server integration
 
 * [vertx-pojo-mapper](https://github.com/BraintagsGmbH/vertx-pojo-mapper) - nonblocking pojo mapping for MySql and MongoDB
 


### PR DESCRIPTION
Enlists https://github.com/cstamas/vertx-orientdb to the list.

The project integrates [OrientDB](http://orientdb.com/orientdb/) with Vert.x.

Thanks.