### PR TITLE
add hystrix-vertx-metrics-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ For vert.x version 2, check [this page](./vert-x2.md).
   * [DropWizard metrics](https://github.com/vert-x3/vertx-dropwizard-metrics) ![(stack)](stack.png "Vert.x Stack") - Metrics implementation using DropWizard metrics
   * [OpenTsDb Metrics](https://github.com/cyngn/vertx-opentsdb) - [OpenTsDb](http://opentsdb.net/) metrics client for vert.x
   * [Bosun Monitoring](https://github.com/cyngn/vertx-bosun) - [Bosun](https://bosun.org/) client library for vert.x
-
+ 
+* Netflix - Hystrix
+  * [Hystrix Metrics Stream](https://github.com/kennedyoliveira/hystrix-vertx-metrics-stream.git) - Emits metrics for Hystrix Dashboard from a Vertx application with [Hystrix](https://github.com/Netflix/Hystrix).
+  
 ## Middleware
 
 * [Gateleen](https://github.com/swisspush/gateleen) - Middleware library based on Vert.x to build advanced JSON/REST communication servers


### PR DESCRIPTION
Hello!

I did a implementation,[hystrix-vertx-metrics-steram](https://github.com/kennedyoliveira/hystrix-vertx-metrics-stream), to add the metrics publishing to a vertx application that uses [Netflix Hystrix](https://github.com/Netflix/Hystrix).


