### PR TITLE
Added Microservices section with standard Vert.x modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 
 * [Docker images](https://github.com/vert-x3/vertx-stack/tree/master/stack-docker) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - Docker images for Vert.x.
 
+## Microservices
+
+* [Discovery Service](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service" height="16px"> - Vert.x Discovery Service.
+* [Circuit Breaker](https://github.com/vert-x3/vertx-circuit-breaker) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Circuit Breaker" height="16px"> - Vert.x Circuit Breaker.
+* [Discovery Service - Consul](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Consul" height="16px"> - [Consul](https://www.consul.io/) extension to Vert.x Discovery Service.
+* [Discovery Service - Docker links](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Docker Links" height="16px"> - [Docker](https://www.docker.com/) extension to Vert.x Discovery Service.
+* [Discovery Service - Kubernetes](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Kubernetes" height="16px"> - [Kubernetes](http://kubernetes.io/) extension to Vert.x Discovery Service.
+* [Discovery Service - Redis backend](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Redis backend" height="16px"> - [Redis](http://redis.io/) storage backend for Vert.x Discovery Service.
+
+
 ## Search Engines
 
 * [Vert.x Elasticsearch Service](https://github.com/englishtown/vertx-elasticsearch-service) - Vert.x 3 [Elasticsearch](https://www.elastic.co/) service with event bus proxying.

--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 
 ## Microservices
 
-* [Discovery Service](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service" height="16px"> - Vert.x Discovery Service.
+* [Service Discovery](https://github.com/vert-x3/vertx-service-discovery) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Service Discovery" height="16px"> - Vert.x Service Discovery.
 * [Circuit Breaker](https://github.com/vert-x3/vertx-circuit-breaker) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Circuit Breaker" height="16px"> - Vert.x Circuit Breaker.
-* [Discovery Service - Consul](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Consul" height="16px"> - [Consul](https://www.consul.io/) extension to Vert.x Discovery Service.
-* [Discovery Service - Docker links](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Docker Links" height="16px"> - [Docker](https://www.docker.com/) extension to Vert.x Discovery Service.
-* [Discovery Service - Kubernetes](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Kubernetes" height="16px"> - [Kubernetes](http://kubernetes.io/) extension to Vert.x Discovery Service.
-* [Discovery Service - Redis backend](https://github.com/vert-x3/vertx-discovery-service) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Discovery Service - Redis backend" height="16px"> - [Redis](http://redis.io/) storage backend for Vert.x Discovery Service.
+* [Service Discovery - Consul](https://github.com/vert-x3/vertx-service-discovery) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Service Discovery - Consul" height="16px"> - [Consul](https://www.consul.io/) extension to Vert.x Service Discovery.
+* [Service Discovery - Docker links](https://github.com/vert-x3/vertx-service-discovery) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Service Discovery - Docker Links" height="16px"> - [Docker](https://www.docker.com/) extension to Vert.x Service Discovery.
+* [Service Discovery - Kubernetes](https://github.com/vert-x3/vertx-service-discovery) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Service Discovery - Kubernetes" height="16px"> - [Kubernetes](http://kubernetes.io/) extension to Vert.x Service Discovery.
+* [Service Discovery - Redis backend](https://github.com/vert-x3/vertx-service-discovery) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Service Discovery - Redis backend" height="16px"> - [Redis](http://redis.io/) storage backend for Vert.x Service Discovery.
 
 
 ## Search Engines

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 - [Cluster Managers](#cluster-managers)
 - [Cloud Support](#cloud-support)
 - [Docker](#docker)
+- [Microservices](#microservices)
 - [Search Engines](#search-engines)
 - [Service Factory](#service-factory)
 - [Dependency Injection](#dependency-injection)


### PR DESCRIPTION
The latest addition of microservices modules released in 3.3.0 were not there yet....so here they are :)
In the next PR I would like to add this repo to this section: https://github.com/engagingspaces/vertx-graphql-service-discovery