### PR TITLE
Vert.x-Dart-SockJS integration entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 
 * Netflix - Hystrix
   * [Hystrix Metrics Stream](https://github.com/kennedyoliveira/hystrix-vertx-metrics-stream.git) - Emits metrics for Hystrix Dashboard from a Vertx application with [Hystrix](https://github.com/Netflix/Hystrix).
+  
+* Dart
+  * [Vert.x Dart SockJS](https://github.com/wem/vertx-dart-sockjs) - [Dart](https://www.dartlang.org/) integration for [Vert.x SockJS bridge](http://vertx.io/docs/vertx-web/java/#_sockjs_event_bus_bridge) and plain SockJS with use of dart:js.
 
 ## Middleware
 


### PR DESCRIPTION
A thin integration layer to use the original Vert.x eventbus.js / sockjs.js 0.3.4 from Dart side. The integration is solved by using the dart:js package.