### PR TITLE
Add vertx-jooq to vertx-awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
   * [MySQL](https://github.com/vert-x3/vertx-mysql-postgresql-client) - Asynchronous client for MySQL.
   * [PostgreSQL](https://github.com/vert-x3/vertx-mysql-postgresql-client) - Asynchronous client for PostgreSQL.
   * [database](https://github.com/susom/database) - Client for Oracle, PostgreSQL, SQL Server, HyperSQL, etc. designed for security, correctness, and ease of use.
+  * [jOOQ](https://github.com/jklingsporn/vertx-jooq) - Doing typesafe, asynchronous SQL and generate code using jOOQ.
 
 * NoSQL Databases
   * [MongoDB](https://github.com/vert-x3/vertx-mongo-client) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - An asynchronous client for interacting with a MongoDB database.


### PR DESCRIPTION
As suggested in the user-group (https://groups.google.com/forum/?fromgroups#!topic/vertx/qlvj-j3UCmI), I've added vertx-jooq. I wasn't sure whether to put it under 'integration' or 'database', but I think it is more likely to be found under the latter.