### PR TITLE
Redesigned Vert.x Elasticsearch Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 ## Search Engines
 
 * [Vert.x Elasticsearch Service](https://github.com/englishtown/vertx-elasticsearch-service) - Vert.x 3 [Elasticsearch](https://www.elastic.co/) service with event bus proxying.
+* [Vert.x Elasticsearch Service (redesign)](https://github.com/hubrick/vertx-elasticsearch-service) - Vert.x 3 [Elasticsearch](https://www.elastic.co/) service with event bus proxying. Redesign of the [Vert.x Elasticsearch Service](https://github.com/englishtown/vertx-elasticsearch-service). Heavy usage of DTOs over eventbus and no more JsonObjects. Added support for ES plugins.
 * [Vert.x Solr Service](https://github.com/englishtown/vertx-solr-service) - Vert.x 3 Solr service with event bus proxying.
 
 ## Service Factory


### PR DESCRIPTION
Added our redesigned version of the https://github.com/englishtown/vertx-elasticsearch-service