### PR TITLE
Added Knot.x to Web frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [vertx-rest-storage](https://github.com/swisspush/vertx-rest-storage) - Persistence for REST resources in the filesystem or a redis database.
 * [Jubilee](https://github.com/isaiah/jubilee) - A rack compatible Ruby HTTP server built on Vert.x 3.
 * [katharsis-vertx](https://github.com/katharsis-project/katharsis-vertx) - [JSONAPI](http://jsonapi.org/) implementation for Vert.x 3.
+* [Knot.x](https://github.com/Cognifide/knotx) - Efficient & high-performance integration platform for modern websites built on Vert.x 3.
 
 ## Authentication Authorisation
 


### PR DESCRIPTION
Proposal to add Knot.x web framework. It depends on Vert.x 3.3.3.
Project repo is [https://github.com/Cognifide/knotx](https://github.com/Cognifide/knotx)
