### PR TITLE
Added Vert..x Jspare to web frameworks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [Jubilee](https://github.com/isaiah/jubilee) - A rack compatible Ruby HTTP server built on Vert.x 3.
 * [katharsis-vertx](https://github.com/katharsis-project/katharsis-vertx) - [JSONAPI](http://jsonapi.org/) implementation for Vert.x 3.
 * [Knot.x](https://github.com/Cognifide/knotx) - Efficient & high-performance integration platform for modern websites built on Vert.x 3.
+* [Vert.x Jspare](https://github.com/jspare-projects/vertx-jspare) - Improving your Vert.x 3 experience with Jspare Framework.
 
 ## Authentication Authorisation
 


### PR DESCRIPTION
Proposal to add Vert.x Jspare to web framework list. This project is already synchronized with the central maven and I believe it is useful.