### PR TITLE
Bitsy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
   * [Redis](https://github.com/vert-x3/vertx-redis-client) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - Asynchronous API to interact with Redis.
   * [Cassandra](https://github.com/englishtown/vertx-cassandra) - Asynchronous API to interact with Cassandra and Cassandra Mapping.
   * [OrientDB](https://github.com/cstamas/vertx-orientdb) - Non-blocking OrientDB server integration.
+  * [Bitsy](https://github.com/cstamas/vertx-bitsy) - Non-blocking Bitsy Graoh server integration.
   * [MarkLogic](https://github.com/etourdot/vertx-marklogic) - Asynchronous client for Marklogic Database Server.
 
 * [vertx-pojo-mapper](https://github.com/BraintagsGmbH/vertx-pojo-mapper) - Non-blocking POJO mapping for MySQL and MongoDB.


### PR DESCRIPTION
Initial draft done, not yet in Central.

Uses Bitsy 1.5.2 and Vert.x 3.3.3

https://bitbucket.org/lambdazen/bitsy/wiki/Home