### PR TITLE
Add a MySQL binary log client

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
   * [MarkLogic](https://github.com/etourdot/vertx-marklogic) - Asynchronous client for Marklogic Database Server.
 
 * [vertx-pojo-mapper](https://github.com/BraintagsGmbH/vertx-pojo-mapper) - Non-blocking POJO mapping for MySQL and MongoDB.
+* [vertx-mysql-binlog-client](https://github.com/guoyu511/vertx-mysql-binlog-client) - A Vert.x client for tapping into MySQL replication stream.
 
 
 ## Integration


### PR DESCRIPTION
A Vert.x client for tapping into MySQL replication stream. Based on Vert.x 3.4.1.

It uses [MySQL Binary Log connector](https://github.com/shyiko/mysql-binlog-connector-java) to 
 connect to MySQL as a slave and handle the binlog events in a vert.x way.

Initial version is published to Maven Central.