### PR TITLE
Add vertx-postgresql-starter to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [HTTP/2 showcase](https://github.com/aesteve/http2-showcase) - A simple demo, showing how HTTP/2 can drastically improve user experience when a huge latency is involved.
 * [Vert.x Music Store](https://github.com/tsegismont/vertx-musicstore) - An example application on how to build Vert.x applications with RxJava
 * [Crabzilla](https://github.com/crabzilla/crabzilla) - Yet another Event Sourcing experiment. A project exploring Vert.x to develop Event Sourcing / CQRS applications.
+* [Vert.x PostgreSQL Starter](https://github.com/BillyYccc/vertx-postgresql-starter) - A starter to build a monolithic CRUD RESTful Web Service with Vert.x stack and postgreSQL
+
 ## Deployment
 
 * [Vert.x Deploy Application](https://github.com/msoute/vertx-deploy-tools) - (Seamless) deploy to AWS based Vert.x application clusters.


### PR DESCRIPTION
This is a starter to build a monolithic CRUD RESTful Web Service with Vert.x stack and postgreSQL. It has been kept up with the newest Vert.x version. Some components introduced in the newest Vert.x 3.5.0 like vertx-web-api-contract and vertx-rx-java2 have been put in use.