### PR TITLE
Adding new reactive library VxRifa

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [Reactive Extensions](https://github.com/vert-x3/vertx-rx) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - Vert.x Reactive Extensions.
 * [vertx-util](https://github.com/cyngn/vertx-util) - Light weight promises & latches for Vert.x.
 * [QBit](https://github.com/advantageous/qbit) - Async typed actor-like lib that runs easily in Vert.x Async Callbacks. Callback management.
+* [VxRifa](https://nsforth.github.io/vxrifa) - Utility library for Vert.X that allows using strong-typed interfaces in communication through EventBus.
 
 ## Sync Thread Non Block
 


### PR DESCRIPTION
Utility library for Vert.X that allows using strong-typed interfaces in communication through EventBus.
It's small and easy to use.