### PR TITLE
Add Cloud Foundry demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [OpenShift DIY cartridge](https://github.com/vert-x3/vertx-openshift-diy-quickstart) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - OpenShift DIY Cartridge using Vert.x.
 * [OpenShift Vert.x cartridge](https://github.com/vert-x3/vertx-openshift-cartridge) <img src="https://rawgit.com/vert-x3/vertx-awesome/d93d327/vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - OpenShift Vert.x Cartridge using Vert.x.
 * [S3](https://github.com/hubrick/vertx-s3-client) - A fully functional Vert.x client for S3.
+* [Cloud Foundry](https://github.com/amdelamar/vertx-cloudfoundry) - An example Vert.x for deploying to a [Cloud Foundry](https://www.cloudfoundry.org/) service provider.
 
 ## Docker
 


### PR DESCRIPTION
A simple demonstration of how to deploy Vert.x Java applications on Cloud Foundry using the java-buildpack.

Source code is here: [amdelamar/vertx-cloudfoundry](https://github.com/amdelamar/vertx-cloudfoundry), 
and recently added here: [vert-x3/vertx-examples/cloudfoundry-example](https://github.com/vert-x3/vertx-examples/tree/master/cloudfoundry-example)