### PR TITLE
Adding GDH project

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [vertx-redisques](https://github.com/swisspush/vertx-redisques) - A highly scalable redis-persistent queuing system for Vert.x.
 * [Simple File Server](https://github.com/pitchpoint-solutions/sfs) - An OpenStack Swift compatible distributed object storage server that can serve and securely store billions of large and small files using minimal resources implemented using Vert.x.
 * [Vert.x Boot](https://github.com/jponge/vertx-boot) - Deploying verticles from a HOCON configuration.
+* [GDH](https://github.com/maxamel/GDH) - Generalized Diffie-Hellman key exchange Java library built on top of Vert.x
 
 ## Distribution
 


### PR DESCRIPTION
Adding GDH project to miscellaneous. The project is a Java library built on top of Vert.x to allow Generalized Diffie-Hellman key exchange between multiple Vert.x verticles.