### PR TITLE
Add Vert.x Vaadin in Web Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [Irked](https://github.com/GreenfieldTech/irked) - Annotations-based configuration for Vert.x 3 Web and controller framework.
 * [REST.VertX](https://github.com/zandero/rest.vertx) - Lightweight JAX-RS (RestEasy) like annotation processor for Vert.x verticals.
 * [Atmosphere Vert.x](https://github.com/Atmosphere/atmosphere-vertx) - Realtime Client Server Framework for the JVM, supporting WebSockets and Server Sent Events with Cross-Browser Fallbacks.
+* [Vert.x Vaadin](https://github.com/mcollovati/vertx-vaadin) - Run Vaadin applications on Vert.x
 
 ## Authentication Authorisation
 


### PR DESCRIPTION
Vert.x Vaadin lets Vaadin application run on Vert.x instead of servlet environment

Here's a demo running Vaadin 8.3.1 on Vert.x 3.5.1: http://vertx-vaadin-example.herokuapp.com/
Github repository:  https://github.com/mcollovati/vertx-vaadin