### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 * [C++11](https://github.com/julien3/vertxbuspp) - C++11 event bus client.
 * [Java](https://github.com/saffron-technology/vertx-eventbusbridge) - Java implementation of vertxbus.js.
 * [Java](https://github.com/abdlquadri/vertx-eventbus-java) - Java and Android Event Bus Client.
+* [Java](https://github.com/danielstieger/javaxbus) - Simple Java Event Bus Client using plain TCP socket I/O
 * [CLI](https://github.com/cinterloper/vxc) - Command-line binary client for Vert.x event bus - pipe in JSON, emit JSON.
 * [Swift](https://github.com/tobias/vertx-swift-eventbus) - Event bus client for [Apple's Swift](https://swift.org) using the [TCP-based protocol](https://github.com/vert-x3/vertx-tcp-eventbus-bridge).
 * [Python](https://github.com/jaymine/TCP-eventbus-client-Python) - Event bus client for Python using the [TCP-based protocol](https://github.com/vert-x3/vertx-tcp-eventbus-bridge).


### PR DESCRIPTION
Added a simple java eventbus client for the tcp-event-bus-bridge. No dependencies toward other frameworks, no netty, no vertx. Just using a thread and plain socket i/o to communication with the bridge. The implementation is capable of reconnecting to the bridge, neat shutdown and cleanup checked ...

Might be of interest for devs working on a rich-client or in a tomcat environment ...