### PR TITLE
Add firestore connector lib - Vert.x 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
   * [MarkLogic](https://github.com/etourdot/vertx-marklogic) - Asynchronous client for Marklogic Database Server.
   * [SirixDB](https://github.com/sirixdb/sirix/tree/master/bundles/sirix-rest-api) - Non-blocking SirixDB HTTP-server.
   * [DGraph](https://github.com/aesteve/vertx-dgraph-client) - An example on how to build a Vert.x gRPC compliant client. Here targeting [dgraph](https://dgraph.io)
+  * [RxFirestore](https://github.com/pjgg/rxfirestore) - Non-blocking Firestore SDK written in a reactive way.
 
 * [vertx-pojo-mapper](https://github.com/BraintagsGmbH/vertx-pojo-mapper) - Non-blocking POJO mapping for MySQL and MongoDB.
 * [vertx-mysql-binlog-client](https://github.com/guoyu511/vertx-mysql-binlog-client) - A Vert.x client for tapping into MySQL replication stream.


### PR DESCRIPTION
**RxFirestore Connector Lib URL**: https://github.com/pjgg/rxfirestore

**Short Description**: Non-blocking Gcloud Firestore SDK written in a reactive way.

**Expected section**: NoSQL Databases