### PR TITLE
remove deprecated vertx-mongo-streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 
 * [vertx-pojo-mapper](https://github.com/BraintagsGmbH/vertx-pojo-mapper) - Non-blocking POJO mapping for MySQL and MongoDB.
 * [vertx-mysql-binlog-client](https://github.com/guoyu511/vertx-mysql-binlog-client) - A Vert.x client for tapping into MySQL replication stream.
-* [vertx-mongo-streams](https://github.com/st-h/vertx-mongo-streams) - Helpers to pump Vert.x streams to/from MongoDB GridFS using the MongoDB async driver.
 
 ## Integration
 


### PR DESCRIPTION
request to remove [vertx-mongo-streams](https://github.com/st-h/vertx-mongo-streams) as I just deprecated it. Mongodb made significant changes to their driver and we do no longer have a need to use the GridFS feature (support of GridFS was vertx-mongo-streams primary feature)