### PR TITLE
fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
 
 ## Articles
 
-- [Going reactive with Eclipse Vert.x and RX Java ](http://www.javamagazine.mozaicreader.com/JanFeb2018#&pageSet=32&page=0)
+- [Going reactive with Eclipse Vert.x and RX Java ](https://blogs.oracle.com/javamagazine/going-reactive-with-eclipse-vertx-and-rxjava)
 - [First Steps With Vert.x and Infinispan - Part 2: PUSH API ](https://dzone.com/articles/first-steps-with-vertx-and-infinispan-push-api-par)
 - [First Steps With Vert.x and Infinispan - Part 1: REST API ](https://dzone.com/articles/first-steps-with-vertx-and-infinispan-rest-api)
 - [Location Transparency With Vert.x ](https://dzone.com/articles/location-transparency-with-vertx)


### PR DESCRIPTION
Motivation:

One of the article links was broken. Fixed that by updating it to point to the correct url.

