### PR TITLE
add async aerospike client

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ For Vert.x version 2 check [this page](./vert-x2.md).
   * [DGraph](https://github.com/aesteve/vertx-dgraph-client) - An example on how to build a Vert.x gRPC compliant client. Here targeting [dgraph](https://dgraph.io)
   * [RxFirestore](https://github.com/pjgg/rxfirestore) - Non-blocking Firestore SDK written in a reactive way.
   * [MongoDB](https://github.com/imrafaelmerino/vertx-mongodb-effect) - Pure functional and reactive MongoDB client on top of [Vert.x Effect](https://github.com/imrafaelmerino/vertx-mongodb-effect). Full support for retry, fallback and recovery operations.
+  * [Aerospike](https://github.com/dream11/vertx-aerospike-client) - Asynchronous and Non-blocking API to interact with aerospike server. (Internally uses [AerospikeClient's](https://github.com/aerospike/aerospike-client-java) async commands and handles the result on vertx-context)
 
 * [vertx-pojo-mapper](https://github.com/BraintagsGmbH/vertx-pojo-mapper) - Non-blocking POJO mapping for MySQL and MongoDB.
 * [vertx-mysql-binlog-client](https://github.com/guoyu511/vertx-mysql-binlog-client) - A Vert.x client for tapping into MySQL replication stream.


### PR DESCRIPTION
Signed-off-by: Srijan Gupta <srijan02420@gmail.com>

Motivation:

Adding link to [vertx-aerospike-client](https://github.com/dream11/vertx-aerospike-client).
The Vert.x Aerospike client provides an asynchronous API to interact with aerospike server. (Internally uses AerospikeClient's async commands and handles the result on vertx-context).
