### PR TITLE
Add the Exposed Vert.x SQL Client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ next to it. This icon means the component is part of the official
   * [database](https://github.com/susom/database) - Client for Oracle, PostgreSQL, SQL Server, HyperSQL, etc. designed for security, correctness, and ease of use.
   * [jOOQ](https://github.com/jklingsporn/vertx-jooq) - Doing typesafe, asynchronous SQL and generate code using jOOQ.
   * [jOOQx](https://github.com/zero88/jooqx) - Leverages the power of typesafe SQL from `jOOQ DSL` and uses the reactive and non-blocking SQL driver from Vert.x.
+  * [Exposed Vert.x SQL Client](https://github.com/huanshankeji/exposed-vertx-sql-client) - Kotlin's [Exposed](https://github.com/JetBrains/Exposed) on top of [Vert.x Reactive SQL Client](https://github.com/eclipse-vertx/vertx-sql-client)
 
 * NoSQL Databases
   * [MongoDB](https://github.com/vert-x3/vertx-mongo-client) <img src="vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - An asynchronous client for interacting with a MongoDB database.


### PR DESCRIPTION
Motivation:

[Exposed](https://github.com/JetBrains/Exposed) is a popular ORM framework for Kotiln but runs in the blocking way. [This Exposed Vert.x SQL Client library](https://github.com/huanshankeji/exposed-vertx-sql-client) provides code to integrate Exposed on top of Vert.x Reactive SQL Client, combining ease of use from an ORM and efficiency from Vert.x's reactive/non-blocking approach.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
