### PR TITLE
Add GuicedEE to Microservices section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ next to it. This icon means the component is part of the official
 * [Autonomous Services](https://github.com/mikand13/autonomous-services) - A toolkit for creating autonomous services. An architecture that leverages vert.x and nannoq-tools to provide an event-based reactive architecure without centralized components, neither for communication or data, providing a theoretically linear scalability across the architecture.
 * [Apache ServiceComb Java Chassis](https://github.com/apache/servicecomb-java-chassis) - ServiceComb Java Chassis is a Software Development Kit (SDK) for rapid development of microservices in Java, providing service registration, service discovery, dynamic routing, and service management features.
 * [SmallRye Fault Tolerance](https://github.com/smallrye/smallrye-fault-tolerance) - SmallRye Fault Tolerance is an implementation of Eclipse MicroProfile Fault Tolerance with additional features not defined by the specification. Native support of [Vert.x](https://smallrye.io/docs/smallrye-fault-tolerance/6.2.6/integration/event-loop.html) and [Mutiny](https://smallrye.io/docs/smallrye-fault-tolerance/6.2.6/reference/asynchronous.html#async-types).
+* [GuicedEE](https://guicedee.com) - JPMS-first Java platform built on Guice and Vert.x 5 for modular, reactive, enterprise applications. Provides MicroProfile Config, Health, Metrics, OpenAPI, REST, persistence, and more out of the box.
 
 ## Game development
 


### PR DESCRIPTION
Hi Vert.x team,
I maintain GuicedEE, a JPMS-first Java platform built around Guice dependency injection with Vert.x 5 support for modular, reactive applications.
I'd like to add GuicedEE to the vertx-awesome list under the **Microservices** section, as it is a full application platform (similar in scope to Quarkus) providing MicroProfile Config, Health, Metrics, OpenAPI, REST, persistence, and more — all built on Vert.x 5.
**Suggested entry:**
> [GuicedEE](https://guicedee.com) - JPMS-first Java platform built on Guice and Vert.x 5 for modular, reactive, enterprise applications. Provides MicroProfile Config, Health, Metrics, OpenAPI, REST, persistence, and more out of the box.
Thanks,
Marc