### PR TITLE
Add Neo4j Java Driver Vert.x to database clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ next to it. This icon means the component is part of the official
   * [Redis](https://github.com/vert-x3/vertx-redis-client) <img src="vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - Asynchronous API to interact with Redis.
   * [Cassandra](https://github.com/vert-x3/vertx-cassandra-client) <img src="vertx-favicon.svg" alt="(stack)" title="Vert.x Stack" height="16px"> - A Vert.x client allowing applications to interact with a Cassandra service.
   * [Cassandra](https://github.com/englishtown/vertx-cassandra) - Asynchronous API to interact with Cassandra and Cassandra Mapping.
+  * [Neo4j Java Driver Vert.x](https://github.com/romanbsd/neo4j-java-driver-vertx) - Vert.x wrapper around the Neo4j Java Driver.
   * [OrientDB](https://github.com/cstamas/vertx-orientdb) - Non-blocking OrientDB server integration.
   * [Bitsy](https://github.com/cstamas/vertx-bitsy) - Non-blocking Bitsy Graph server integration.
   * [MarkLogic](https://github.com/etourdot/vertx-marklogic) - Asynchronous client for Marklogic Database Server.


### PR DESCRIPTION
This driver wraps the official driver and provides Future<> APIs
